### PR TITLE
[DRAFT] MultiDB support

### DIFF
--- a/massmigration/backends/djangae.py
+++ b/massmigration/backends/djangae.py
@@ -46,7 +46,6 @@ class DjangaeBackend(BackendBase):
                 self._call_mapper_wrapped_operation,
                 self._mark_mapper_as_finished,
                 key_ranges_getter=key_ranges_getter,
-                using=queryset.db,
                 migration=migration,
                 attempt_uuid=attempt_uuid,
                 _queue=self._get_queue_name(migration),

--- a/massmigration/backends/djangae.py
+++ b/massmigration/backends/djangae.py
@@ -46,6 +46,7 @@ class DjangaeBackend(BackendBase):
                 self._call_mapper_wrapped_operation,
                 self._mark_mapper_as_finished,
                 key_ranges_getter=key_ranges_getter,
+                using=queryset.db,
                 migration=migration,
                 attempt_uuid=attempt_uuid,
                 _queue=self._get_queue_name(migration),

--- a/massmigration/exceptions.py
+++ b/massmigration/exceptions.py
@@ -18,3 +18,14 @@ class RequiredMigrationNotApplied(Exception):
         tried to run when that migration is not yet applied.
     """
     pass
+
+
+class CannotRunOnGivenConnection(Exception):
+    """ Error for when a migration can't be run on a specified connection.
+    """
+    pass
+
+
+class InvalidDbAlias(Exception):
+    """ Error for when an invalid database alias is provided.
+    """

--- a/massmigration/loader.py
+++ b/massmigration/loader.py
@@ -19,6 +19,7 @@ class MigrationsStore:
         self._loaded = False
         self._all = []
         self._by_key = {}
+        self._migrations_by_record_db_alias = {}
 
     @property
     def all(self):
@@ -31,6 +32,12 @@ class MigrationsStore:
         if not self._loaded:
             self.load()
         return self._by_key
+
+    @property
+    def migrations_by_record_db_alias(self):
+        if not self._loaded:
+            self.load()
+        return self._migrations_by_record_db_alias
 
     def load(self):
         """ Load all the migration instances from all migration files found in installed apps. """
@@ -45,6 +52,8 @@ class MigrationsStore:
 
                         for migration in migrations:
                             self._by_key[migration.key] = migration
+                            self._migrations_by_record_db_alias.setdefault(migration.db_for_migration_records, []).append(migration)
+
         self._loaded = True
 
 

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -85,7 +85,14 @@ class BaseMigration:
 
     @cached_property
     def db_for_migration_records(self):
-        return self.get_database_alias_for_migration_records(self.database_alias)
+        db_alias_for_migration_records = self.get_database_alias_for_migration_records(self.database_alias)
+
+        if db_alias_for_migration_records not in _get_valid_db_aliases():
+            valid_db_aliases = [str(x) for x in _get_valid_db_aliases()]
+            raise InvalidDbAlias(f"Invalid db_alias_for_migration_records provided."
+                                 f"Got: <{db_alias_for_migration_records}> but the expected valid database aliases are {', '.join(valid_db_aliases)}.")
+
+        return db_alias_for_migration_records
 
     @property
     def key(self):

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -76,14 +76,13 @@ class BaseMigration:
         If `allowed_database_aliases` is None, the migration can be run on
         all databases.
         """
-        allowed_db_aliases = [no_selected_db_sentinel]
         available_dbs = _get_valid_db_aliases()
 
         if cls.allowed_database_aliases is None:  # If None we assume can run on all DBs
             if len(available_dbs) > 1:  # If we only have one DB there's no need to add it, since we alread have the no_selected_db_sentinel
-                allowed_db_aliases += available_dbs
+                allowed_db_aliases = available_dbs
         else:
-            allowed_db_aliases += cls.allowed_database_aliases
+            allowed_db_aliases =  [no_selected_db_sentinel] + cls.allowed_database_aliases
 
         return allowed_db_aliases
 
@@ -260,7 +259,7 @@ class MapperMigration(BaseMigration):
         """ Returns the Django queryset which is to be mapped over. """
         queryset = self._get_queryset_without_namespace()
         if self.database_alias is not no_selected_db_sentinel:
-            queryset = queryset.using(self.db_for_migration_records)
+            queryset = queryset.using(self.database_alias)
 
         return queryset
 

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -82,7 +82,7 @@ class BaseMigration:
             if len(available_dbs) > 1:  # If we only have one DB there's no need to add it, since we alread have the no_selected_db_sentinel
                 allowed_db_aliases = available_dbs
         else:
-            allowed_db_aliases =  [no_selected_db_sentinel] + cls.allowed_database_aliases
+            allowed_db_aliases = cls.allowed_database_aliases
 
         return allowed_db_aliases
 

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -219,6 +219,19 @@ class BaseMigration:
 
         return None
 
+    def get_migration_record(self):
+        """
+        Returns the migration record for the migration.
+
+        Returns:
+        - MigrationRecord: The migration record for the migration.
+        """
+        try:
+            return MigrationRecord.objects.using(self.db_for_migration_records).get(key=self.key)
+        except MigrationRecord.DoesNotExist:
+            return None
+
+
 
 class SimpleMigration(BaseMigration):
     """ A migration which only needs to apply a very quick and simple change to the database which

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -76,9 +76,9 @@ class BaseMigration:
         If `allowed_database_aliases` is None, the migration can be run on
         all databases.
         """
-        available_dbs = _get_valid_db_aliases()
 
         if cls.allowed_database_aliases is None:  # If None we assume can run on all DBs
+            available_dbs = _get_valid_db_aliases()
             if len(available_dbs) > 1:  # If we only have one DB there's no need to add it, since we alread have the no_selected_db_sentinel
                 allowed_db_aliases = available_dbs
         else:

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -82,7 +82,7 @@ class BaseMigration:
             if len(available_dbs) > 1:  # If we only have one DB there's no need to add it, since we alread have the no_selected_db_sentinel
                 allowed_db_aliases = available_dbs
         else:
-            allowed_db_aliases = cls.allowed_database_aliases
+            allowed_db_aliases = cls.allowed_database_aliases + [no_selected_db_sentinel]
 
         return allowed_db_aliases
 

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -100,7 +100,7 @@ class BaseMigration:
 
     @cached_property
     def db_for_migration_records(self):
-        return self.get_database_alias_for_migration_records()
+        return self.get_database_alias_for_migration_records(self.database_alias)
 
     @property
     def key(self):

--- a/massmigration/migrations.py
+++ b/massmigration/migrations.py
@@ -171,7 +171,7 @@ class BaseMigration:
 
     def mark_as_started(self) -> UUID:
         """ Mark the migration as started in the database. Return the attempt UUID. """
-        with get_transaction().atomic(using=self.database_alias):
+        with get_transaction().atomic(using=self.db_for_migration_records):
             if not self.can_be_started():
                 raise MigrationAlreadyStarted(
                     f"Migration {self.__class__.__name__} has already been initiated."
@@ -189,7 +189,7 @@ class BaseMigration:
     @retry_on_error()
     def mark_as_finished(self):
         """ Mark the migration as applied/finalized in the database. """
-        with get_transaction().atomic(using=self.database_alias):
+        with get_transaction().atomic(using=self.db_for_migration_records):
             migration = MigrationRecord.objects.using(self.db_for_migration_records).get(key=self.key)
             if migration.is_applied:
                 logger.warning("Migration %s is already marked as applied.", self.key)

--- a/massmigration/templates/massmigration/manage_migrations.html
+++ b/massmigration/templates/massmigration/manage_migrations.html
@@ -8,6 +8,7 @@
 		<tr>
 			<th>App</th>
 			<th>Migration</th>
+			<th>DB</th>
 			<th>Status</th>
 			<th>Actions</th>
 		</tr>
@@ -17,6 +18,7 @@
 		<tr>
 			<td>{{migration.app_label}}</td>
 			<td><a href="{% url 'massmigration_detail' key=migration.key %}">{{migration.name}}</a></td>
+			<td>{{migration.database_alias}}</td>
 			<td>{% if migration.record %}{{migration.record.status}}{% else %}NOT RUN{% endif %}</td>
 			<td>
 				{% if not migration.record %}<a href="{% url 'massmigration_run' key=migration.key %}">Run...</a>

--- a/massmigration/templates/massmigration/manage_migrations.html
+++ b/massmigration/templates/massmigration/manage_migrations.html
@@ -18,7 +18,7 @@
 		<tr>
 			<td>{{migration.app_label}}</td>
 			<td><a href="{% url 'massmigration_detail' key=migration.key %}">{{migration.name}}</a></td>
-			<td>{{migration.database_alias}}</td>
+			<td>{{migration.database_alias|default:"autoselect_db"}}</td>
 			<td>{% if migration.record %}{{migration.record.status}}{% else %}NOT RUN{% endif %}</td>
 			<td>
 				{% if not migration.record %}<a href="{% url 'massmigration_run' key=migration.key %}">Run...</a>

--- a/massmigration/templates/massmigration/migration_detail.html
+++ b/massmigration/templates/massmigration/migration_detail.html
@@ -12,6 +12,10 @@
 		<td>{{migration.backend_str}}</td>
 	</tr>
 	<tr scope="row">
+		<th>Database</th>
+		<td>{{migration.database_alias|default:"autoselect_db"}}</td>
+	</tr>
+	<tr scope="row">
 		<th>Dependencies</th>
 		<td>
 			{% for dependency in dependencies %}

--- a/massmigration/templates/massmigration/run_migration.html
+++ b/massmigration/templates/massmigration/run_migration.html
@@ -6,7 +6,7 @@
 <h2>{{migration.key}}</h2>
 <p>{{migration.description}}</p>
 <p class="pt">
-	This will launch the processing of the migration using the backend <code>{{migration.backend_str}}</code>.
+	This will launch the processing of the migration using the backend <code>{{migration.backend_str}} on {{migration.database_alias|"autoselect_db"}} db</code>.
 </p>
 
 <form method="post" action="" class="pt">

--- a/massmigration/templates/massmigration/run_migration.html
+++ b/massmigration/templates/massmigration/run_migration.html
@@ -6,7 +6,7 @@
 <h2>{{migration.key}}</h2>
 <p>{{migration.description}}</p>
 <p class="pt">
-	This will launch the processing of the migration using the backend <code>{{migration.backend_str}} on {{migration.database_alias|"autoselect_db"}} db</code>.
+	This will launch the processing of the migration using the backend <code>{{migration.backend_str}} on {{migration.database_alias|default:"autoselect_db"}} db</code>.
 </p>
 
 <form method="post" action="" class="pt">


### PR DESCRIPTION
This PR is to add support to mass-migration to multiple DBs.

### Assumptions

- There's a requirement to be able to force a migration to run on specific databases
- By default, the migration can run on any DB
- There's always the option to run the migration letting django decide which database to use (so even when `allowed_db_aliases = []` the migration can still be run).
- Migration records might be stored on a different DB from the migration one.
- Migration records are stored on the default database by default.
- For the first iteration of this, all the different migrations against different dbs are all listed in the `manage` view.


### Todo (in this ticket):
- Update documentation to explain how this all works
- Find a better name for `_get_queryset_without_namespace`

###  Notes:
- This is a breaking change.
- This currently doesn't work because of [this bug](https://gitlab.com/potato-oss/djangae/djangae/-/issues/1368) in djangae. defer_with_finalize always use the default DB.

###  Improvements (different tickets):
- Allow to pick a specific DB from `manage` to filter only those migrations.

